### PR TITLE
Fix the hitch when shooting for the first time

### DIFF
--- a/Flying Gun.tscn
+++ b/Flying Gun.tscn
@@ -1,15 +1,13 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=19 format=2]
 
 [ext_resource path="res://object scenes/Gun.tscn" type="PackedScene" id=1]
-[ext_resource path="res://Models/gun_texture.png" type="Texture" id=2]
-[ext_resource path="res://Sprites/circle_05_transparent.png" type="Texture" id=3]
+[ext_resource path="res://highlight_material.tres" type="Material" id=2]
+[ext_resource path="res://glow_material.tres" type="Material" id=3]
+[ext_resource path="res://Sprites/circle_05_transparent.png" type="Texture" id=4]
 
 [sub_resource type="PhysicsMaterial" id=1]
 
 friction = 0.28
-rough = false
-bounce = 0.0
-absorbent = false
 
 [sub_resource type="GDScript" id=2]
 
@@ -34,10 +32,10 @@ func _ready():
 	pickupArea = get_node(\"Pickup Area\")
 	pickupArea.monitoring = false
 	start()
-	
+
 func start():
 	yield(delay(0.05), \"timeout\")
-	apply_torque_impulse(get_transform().basis.x * spin_speed)	
+	apply_torque_impulse(get_transform().basis.x * spin_speed)
 	yield(delay(0.5), \"timeout\")
 	pickupArea.monitoring = true
 
@@ -45,39 +43,39 @@ func glow():
 	get_node(\"Glow Through Wall\").visible = false;
 	get_node(\"Highlighted Gun\").visible = true
 	get_node(\"Gun\").visible = false
-	
+
 func unglow():
 	get_node(\"Glow Through Wall\").visible = true;
 	get_node(\"Highlighted Gun\").visible = false
 	get_node(\"Gun\").visible = true
-	
+
 func recall(left):
 	recalling = true
 	gravity_scale = 0
 	sideMovementRight = !left
 	sideMovementElapsed = 0
-	
+
 func cantRecall():
 	recalling = false
 	gravity_scale = originalGravityScale
-	
+
 func _process(delta):
 	if not player:
 		player = get_node(\"/root/Game\").find_node(\"Player\", true, false)
 	if (recalling):
 		sideMovementElapsed += delta
-		
+
 func _physics_process(delta):
 	if (recalling):
 		if (sideMovementElapsed < sideMovementTime):
 			var dir = player.pitch.global_transform.basis.x if sideMovementRight else -player.pitch.global_transform.basis.x
 			add_central_force(side_movement_force * dir)
-	
+
 func _integrate_forces(state):
 	if (player && recalling):
 		var toPlayer = player.camera.global_transform.origin - global_transform.origin
 		state.add_central_force(toPlayer * recall_accel)
-		
+
 		if (state.linear_velocity.length_squared() > recall_max_speed * recall_max_speed):
 			state.linear_velocity = state.linear_velocity.normalized() * recall_max_speed;
 
@@ -93,362 +91,87 @@ func delay(seconds : float = 1, start : bool = true):
 
 [sub_resource type="SpatialMaterial" id=3]
 
-render_priority = 0
-flags_transparent = false
-flags_unshaded = false
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
-flags_do_not_receive_shadows = false
-flags_disable_ambient_light = false
-flags_ensure_correct_normals = false
-vertex_color_use_as_albedo = false
-vertex_color_is_srgb = false
-params_diffuse_mode = 0
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
-albedo_color = Color( 1, 1, 1, 1 )
-albedo_texture = ExtResource( 2 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
-roughness = 1.0
-roughness_texture_channel = 0
-emission_enabled = true
-emission = Color( 0.501961, 0.501961, 0.501961, 1 )
-emission_energy = 1.0
-emission_operator = 0
-emission_on_uv2 = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_mode = 0
-_sections_unfolded = [ "Albedo", "Emission" ]
-
-[sub_resource type="SpatialMaterial" id=4]
-
-render_priority = 0
-flags_transparent = true
-flags_unshaded = false
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
-flags_do_not_receive_shadows = false
-flags_disable_ambient_light = false
-flags_ensure_correct_normals = false
-vertex_color_use_as_albedo = false
-vertex_color_is_srgb = false
-params_diffuse_mode = 0
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
-albedo_color = Color( 1, 1, 1, 0.337255 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
-roughness = 1.0
-roughness_texture_channel = 0
-emission_enabled = true
-emission = Color( 1, 0.960784, 0, 1 )
-emission_energy = 1.5
-emission_operator = 0
-emission_on_uv2 = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_mode = 0
-_sections_unfolded = [ "Albedo", "Emission", "Rim", "Transmission" ]
-
-[sub_resource type="SpatialMaterial" id=5]
-
 render_priority = 1
 flags_transparent = true
 flags_unshaded = true
 flags_vertex_lighting = true
 flags_no_depth_test = true
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
 flags_do_not_receive_shadows = true
 flags_disable_ambient_light = true
-flags_ensure_correct_normals = false
-vertex_color_use_as_albedo = false
-vertex_color_is_srgb = false
-params_diffuse_mode = 0
-params_specular_mode = 0
-params_blend_mode = 0
-params_cull_mode = 0
-params_depth_draw_mode = 0
-params_line_width = 1.0
-params_point_size = 1.0
-params_billboard_mode = 0
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
 albedo_color = Color( 1, 0.956863, 0, 0.278431 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
-roughness = 1.0
-roughness_texture_channel = 0
-emission_enabled = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_mode = 0
-_sections_unfolded = [ "Albedo", "Flags", "Parameters" ]
 
-[sub_resource type="CapsuleShape" id=6]
+[sub_resource type="CapsuleShape" id=4]
 
-margin = 0.04
 radius = 0.1571
 height = 0.383166
 
-[sub_resource type="CapsuleShape" id=7]
+[sub_resource type="CapsuleShape" id=5]
 
-margin = 0.04
 radius = 0.103633
 height = 0.678108
 
-[sub_resource type="Gradient" id=8]
+[sub_resource type="Gradient" id=6]
 
 offsets = PoolRealArray( 0, 0.856397, 1 )
 colors = PoolColorArray( 1, 0, 0, 1, 0.0339426, 0, 0, 1, 0, 0, 0, 1 )
 
-[sub_resource type="GradientTexture" id=9]
+[sub_resource type="GradientTexture" id=7]
 
-flags = 4
-gradient = SubResource( 8 )
-width = 2048
-_sections_unfolded = [ "gradient" ]
+gradient = SubResource( 6 )
 
-[sub_resource type="Curve" id=10]
+[sub_resource type="Curve" id=8]
 
-min_value = 0.0
-max_value = 1.0
-bake_resolution = 100
 _data = [ Vector2( 0, 1 ), 0.0, 0.0, 0, 0, Vector2( 1, 0 ), -3.64284, 0.0, 0, 0 ]
 
-[sub_resource type="CurveTexture" id=11]
+[sub_resource type="CurveTexture" id=9]
 
-flags = 4
-width = 2048
-curve = SubResource( 10 )
-_sections_unfolded = [ "curve" ]
+curve = SubResource( 8 )
 
-[sub_resource type="ParticlesMaterial" id=12]
+[sub_resource type="ParticlesMaterial" id=10]
 
-render_priority = 0
-trail_divisor = 1
-emission_shape = 0
-flag_align_y = false
-flag_rotate_y = false
-flag_disable_z = false
 spread = 0.0
-flatness = 0.0
 gravity = Vector3( 0, 0, 0 )
-initial_velocity = 0.0
-initial_velocity_random = 0.0
-angular_velocity = 0.0
-angular_velocity_random = 0.0
-linear_accel = 0.0
-linear_accel_random = 0.0
-radial_accel = 0.0
-radial_accel_random = 0.0
-tangential_accel = 0.0
-tangential_accel_random = 0.0
-damping = 0.0
-damping_random = 0.0
-angle = 0.0
-angle_random = 0.0
-scale = 1.0
-scale_random = 0.0
-scale_curve = SubResource( 11 )
-color_ramp = SubResource( 9 )
-hue_variation = 0.0
-hue_variation_random = 0.0
-anim_speed = 0.0
-anim_speed_random = 0.0
-anim_offset = 0.0
-anim_offset_random = 0.0
-anim_loop = false
-_sections_unfolded = [ "Animation", "Emission Shape", "Hue Variation", "Initial Velocity", "Resource", "Spread", "Trail", "color_ramp", "scale_curve" ]
+angular_velocity = 4.48416e-43
+scale_curve = SubResource( 9 )
+color_ramp = SubResource( 7 )
 
-[sub_resource type="SpatialMaterial" id=13]
+[sub_resource type="SpatialMaterial" id=11]
 
-render_priority = 0
 flags_transparent = true
 flags_unshaded = true
-flags_vertex_lighting = false
-flags_no_depth_test = false
-flags_use_point_size = false
-flags_world_triplanar = false
-flags_fixed_size = false
-flags_albedo_tex_force_srgb = false
 flags_do_not_receive_shadows = true
 flags_disable_ambient_light = true
-flags_ensure_correct_normals = false
 vertex_color_use_as_albedo = true
-vertex_color_is_srgb = false
-params_diffuse_mode = 0
-params_specular_mode = 0
 params_blend_mode = 1
-params_cull_mode = 0
 params_depth_draw_mode = 3
 params_line_width = 0.1
-params_point_size = 1.0
 params_billboard_mode = 3
-params_billboard_keep_scale = false
-params_grow = false
-params_use_alpha_scissor = false
 particles_anim_h_frames = 1
 particles_anim_v_frames = 1
-particles_anim_loop = 0
-albedo_color = Color( 1, 1, 1, 1 )
-albedo_texture = ExtResource( 3 )
-metallic = 0.0
-metallic_specular = 0.5
-metallic_texture_channel = 0
-roughness = 1.0
-roughness_texture_channel = 0
-emission_enabled = false
-normal_enabled = false
-rim_enabled = false
-clearcoat_enabled = false
-anisotropy_enabled = false
-ao_enabled = false
-depth_enabled = false
-subsurf_scatter_enabled = false
-transmission_enabled = false
-refraction_enabled = false
-detail_enabled = false
-uv1_scale = Vector3( 1, 1, 1 )
-uv1_offset = Vector3( 0, 0, 0 )
-uv1_triplanar = false
-uv1_triplanar_sharpness = 1.0
-uv2_scale = Vector3( 1, 1, 1 )
-uv2_offset = Vector3( 0, 0, 0 )
-uv2_triplanar = false
-uv2_triplanar_sharpness = 1.0
-proximity_fade_enable = false
-distance_fade_mode = 0
-_sections_unfolded = [ "Albedo", "Flags", "Parameters", "Subsurf Scatter", "Vertex Color", "albedo_texture" ]
+particles_anim_loop = false
+albedo_texture = ExtResource( 4 )
 
-[sub_resource type="QuadMesh" id=14]
+[sub_resource type="QuadMesh" id=12]
 
-material = SubResource( 13 )
-custom_aabb = AABB( 0, 0, 0, 0, 0, 0 )
-flip_faces = false
+material = SubResource( 11 )
 size = Vector2( 0.3, 0.3 )
-_sections_unfolded = [ "Resource" ]
 
-[sub_resource type="SphereShape" id=15]
+[sub_resource type="SphereShape" id=13]
 
-margin = 0.04
 radius = 1.4215
 
-[sub_resource type="SphereShape" id=16]
+[sub_resource type="SphereShape" id=14]
 
-margin = 0.04
 radius = 1.42896
 
 [node name="Flying Gun" type="RigidBody"]
-input_ray_pickable = true
-input_capture_on_drag = false
-collision_layer = 1
-collision_mask = 1
-mode = 0
 mass = 10.0
 physics_material_override = SubResource( 1 )
 gravity_scale = 0.1
-custom_integrator = false
 continuous_cd = true
 contacts_reported = 3
 contact_monitor = true
-sleeping = false
-can_sleep = true
-axis_lock_linear_x = false
-axis_lock_linear_y = false
-axis_lock_linear_z = false
-axis_lock_angular_x = false
-axis_lock_angular_y = false
-axis_lock_angular_z = false
-linear_velocity = Vector3( 0, 0, 0 )
-linear_damp = -1.0
-angular_velocity = Vector3( 0, 0, 0 )
-angular_damp = -1.0
 script = SubResource( 2 )
-_sections_unfolded = [ "Angular", "Axis Lock", "Collision", "Linear", "Transform", "physics_material_override" ]
 recall_accel = 140.0
 recall_max_speed = 14.0
 spin_speed = -8.0
@@ -458,127 +181,61 @@ side_movement_time = 0.4
 [node name="Gun" parent="." instance=ExtResource( 1 )]
 editor/display_folded = true
 transform = Transform( -0.75, 0, 6.55671e-08, 0, 0.75, 0, -6.55671e-08, 0, -0.75, 0, 0, 0 )
-_sections_unfolded = [ "Transform" ]
 
 [node name="Highlighted Gun" parent="." instance=ExtResource( 1 )]
 transform = Transform( -0.75, 0, 6.55671e-08, 0, 0.75, 0, -6.55671e-08, 0, -0.75, 0, 0, 0 )
-visible = false
-_sections_unfolded = [ "Transform" ]
 
 [node name="MeshInstance" parent="Highlighted Gun" index="0"]
-material/0 = SubResource( 3 )
+material/0 = ExtResource( 2 )
 
 [node name="Glow" parent="Highlighted Gun" instance=ExtResource( 1 )]
 transform = Transform( 1.3573, 0, -2.13163e-14, 0, 1.3573, 0, 2.13163e-14, 0, 1.3573, 7.32497e-08, -0.139806, -0.0711843 )
 
 [node name="MeshInstance" parent="Highlighted Gun/Glow" index="0"]
-material/0 = SubResource( 4 )
+material/0 = ExtResource( 3 )
 
 [node name="Glow Through Wall" parent="." instance=ExtResource( 1 )]
 transform = Transform( -0.75, 0, 1.13247e-07, 0, 0.75, 0, -1.13247e-07, 0, -0.75, 0, 0, 0 )
-_sections_unfolded = [ "Transform" ]
 
 [node name="MeshInstance" parent="Glow Through Wall" index="0"]
 transform = Transform( 0.196, 0, 0, 0, 0.196, 0, 0, 0, 0.196, 0, 0, 0 )
-material/0 = SubResource( 5 )
-_sections_unfolded = [ "Material", "Transform", "material" ]
+material/0 = SubResource( 3 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, 1, 0, -1, -4.37114e-08, 0, 0.0990103, -0.208082 )
-shape = SubResource( 6 )
-disabled = false
-_sections_unfolded = [ "Transform" ]
+shape = SubResource( 4 )
 
 [node name="CollisionShape2" type="CollisionShape" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.310561, 0.0495731 )
-shape = SubResource( 7 )
-disabled = false
+shape = SubResource( 5 )
 
 [node name="Particles" type="Particles" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.17147, -0.198528 )
-layers = 1
-material_override = null
-cast_shadow = 1
-extra_cull_margin = 0.0
-use_in_baked_light = false
-lod_min_distance = 0.0
-lod_min_hysteresis = 0.0
-lod_max_distance = 0.0
-lod_max_hysteresis = 0.0
-emitting = true
 amount = 3000
 lifetime = 5.0
-one_shot = false
-preprocess = 0.0
-speed_scale = 1.0
-explosiveness = 0.0
-randomness = 0.0
-fixed_fps = 0
-fract_delta = true
 visibility_aabb = AABB( -4.00635, -4, -3.70996, 8, 8, 8 )
 local_coords = false
 draw_order = 2
-process_material = SubResource( 12 )
-draw_passes = 1
-draw_pass_1 = SubResource( 14 )
-_sections_unfolded = [ "Draw Passes", "Drawing", "Geometry", "Lod", "Process Material", "Time", "draw_pass_1", "process_material" ]
+process_material = SubResource( 10 )
+draw_pass_1 = SubResource( 12 )
 
 [node name="Gun Target Area" type="Area" parent="."]
 input_ray_pickable = true
-input_capture_on_drag = false
-space_override = 0
-gravity_point = false
-gravity_distance_scale = 0.0
-gravity_vec = Vector3( 0, -1, 0 )
-gravity = 9.8
-linear_damp = 0.1
-angular_damp = 1.0
-priority = 0.0
-monitoring = true
-monitorable = true
 collision_layer = 2
 collision_mask = 2
-audio_bus_override = false
-audio_bus_name = "Master"
-reverb_bus_enable = false
-reverb_bus_name = "Master"
-reverb_bus_amount = 0.0
-reverb_bus_uniformity = 0.0
-_sections_unfolded = [ "Collision" ]
 
 [node name="CollisionShape" type="CollisionShape" parent="Gun Target Area"]
 transform = Transform( 1.2, 0, 0, 0, 1.2, 0, 0, 0, 1.2, 0, 0, 0 )
-shape = SubResource( 15 )
-disabled = false
+shape = SubResource( 13 )
 
 [node name="Pickup Area" type="Area" parent="."]
-input_ray_pickable = false
-input_capture_on_drag = false
-space_override = 0
-gravity_point = false
-gravity_distance_scale = 0.0
-gravity_vec = Vector3( 0, -1, 0 )
-gravity = 9.8
-linear_damp = 0.1
-angular_damp = 1.0
-priority = 0.0
 monitoring = false
-monitorable = true
 collision_layer = 4
 collision_mask = 4
-audio_bus_override = false
-audio_bus_name = "Master"
-reverb_bus_enable = false
-reverb_bus_name = "Master"
-reverb_bus_amount = 0.0
-reverb_bus_uniformity = 0.0
-_sections_unfolded = [ "Collision" ]
 
 [node name="CollisionShape" type="CollisionShape" parent="Pickup Area"]
 transform = Transform( 1.2, 0, 0, 0, 1.2, 0, 0, 0, 1.2, 0, 0, 0 )
-shape = SubResource( 16 )
-disabled = false
-_sections_unfolded = [ "Transform" ]
+shape = SubResource( 14 )
 
 
 [editable path="Highlighted Gun"]

--- a/Game.tscn
+++ b/Game.tscn
@@ -35,12 +35,14 @@ var chosen_levels
 var textSound
 
 func _ready():
+	var material = preload(\"res://glow_material.tres\")
+	material = preload(\"res://highlight_material.tres\")
 	levelHolder = get_node(\"Current Level\")
 	bigText = get_node(\"Overlay UI/Big Text\")
 	textSound = get_node(\"TextSound\")
 	tween = get_node(\"Tween\")
 	start_over()
-	
+
 func slomo(secondsFixed : float, amount: float):
 	Engine.time_scale = amount
 	isSlomo = true
@@ -59,18 +61,18 @@ func _process(delta):
 			Engine.time_scale = timeScale
 			if timeScale == 1:
 				isSlomo = false
-				
+
 func start_over():
 	chosen_levels = null
 	currentLevelIndex = -1
 	set_level(start_level)
-	
+
 func choose_level_type(type):
 	if type == \"hard\":
 		chosen_levels = hard_game_levels
 	else:
 		chosen_levels = game_levels
-				
+
 func next_level():
 	if not chosen_levels: return
 	currentLevelIndex += 1
@@ -79,14 +81,14 @@ func next_level():
 		return
 	var newLevel = load(chosen_levels[currentLevelIndex])
 	set_level(newLevel)
-	
+
 func restart_level():
 	set_level(load(chosen_levels[currentLevelIndex]))
-	
+
 func set_level(level : PackedScene):
 	Engine.time_scale = 1
 	get_tree().paused = false
-	
+
 	if is_instance_valid(current_level):
 		current_level.queue_free()
 		yield(get_tree(), \"idle_frame\")
@@ -101,50 +103,50 @@ func player_died():
 	var dead = get_node(\"Overlay UI\").find_node(\"Dead\")
 	dead.visible = true
 	tween().interpolate_property(dead, \"modulate:a\", 0.5, 1, 1, Tween.TRANS_QUAD, Tween.EASE_OUT)
-	
+
 	yield(delay(2, true, false), \"timeout\")
-	
+
 	restart_level()
 	dead.modulate.a = 0
 	dead.visible = false
-	
+
 func delay(seconds : float = 1, start : bool = true, pausable : bool = true):
 	var timer = Timer.new()
-	
+
 	var parent = get_node(\"Current Level\") if pausable else self
 	parent.add_child(timer)
-	
+
 	timer.one_shot = true
 	timer.wait_time = seconds
 	if start:
 		timer.start()
 	return timer
-	
+
 func clearBigText():
 	bigText.text = \"\"
-	
+
 func showBigText(text : String, totalTime : float = 2):
 	if currentBigTextTimer and !currentBigTextTimer.is_stopped():
 		currentBigTextTimer.stop()
-	
+
 	var words = text.split(\" \")
 	var timer = delay(totalTime / words.size())
 	timer.one_shot = false
 	currentBigTextTimer = timer
-	
+
 	for word in words:
 		textSound.play()
 		bigText.text = word
 		bigText.rect_scale = Vector2(1.0, 1.0)
-		tween.interpolate_property(bigText, \"rect_scale\", 
+		tween.interpolate_property(bigText, \"rect_scale\",
 			Vector2(1.0, 1.0),
 			Vector2(0.75, 0.75),
 			min(0.5, timer.wait_time), Tween.TRANS_QUAD, Tween.EASE_OUT)
 		tween.start()
 		yield(timer, \"timeout\")
-	
+
 	clearBigText()
-	
+
 func playGameName(times : int):
 	var timer = delay(0.65, true, false)
 	timer.one_shot = false
@@ -156,10 +158,10 @@ func playGameName(times : int):
 		get_node(\"Audio/Cold\").pitch_scale = Engine.time_scale
 		get_node(\"Audio/Cold\").play()
 		yield(timer, \"timeout\")
-	
+
 func level_add(obj):
 	current_level.add_child(obj)
-	
+
 func tween():
 	var tween = Tween.new()
 	add_child(tween)

--- a/glow_material.tres
+++ b/glow_material.tres
@@ -1,0 +1,11 @@
+[gd_resource type="SpatialMaterial" format=2]
+
+[resource]
+flags_transparent = true
+albedo_color = Color( 1, 1, 1, 0.337255 )
+emission_enabled = true
+emission = Color( 1, 0.960784, 0, 1 )
+emission_energy = 1.5
+emission_operator = 0
+emission_on_uv2 = false
+

--- a/highlight_material.tres
+++ b/highlight_material.tres
@@ -1,0 +1,12 @@
+[gd_resource type="SpatialMaterial" load_steps=2 format=2]
+
+[ext_resource path="res://Models/gun_texture.png" type="Texture" id=1]
+
+[resource]
+albedo_texture = ExtResource( 1 )
+emission_enabled = true
+emission = Color( 0.501961, 0.501961, 0.501961, 1 )
+emission_energy = 1.0
+emission_operator = 0
+emission_on_uv2 = false
+


### PR DESCRIPTION
- As the "gun/bullet" materials use emission they take some time to load (the shader has to be compiled).
- Godot loads resources the first time they're used. So on the first shot these "heavy" materials are compiled, halting the scene for a second
- The fix is to preload the materials in the Game scene, so they are loaded when the application is launched